### PR TITLE
Remove file extension from file name

### DIFF
--- a/SAMSoundEffect/SAMSoundEffect.m
+++ b/SAMSoundEffect/SAMSoundEffect.m
@@ -60,7 +60,7 @@
 	
 	SAMSoundEffect *cachedSoundEffect = [[self _cache] objectForKey:name];
 	if (!cachedSoundEffect) {
-		NSString *fileName = [[name pathComponents] lastObject];
+		NSString *fileName = [[[name pathComponents] lastObject] stringByDeletingPathExtension];
 		NSString *fileExtension = [name pathExtension];
 		if ([fileExtension isEqualToString:@""]) {
 			fileExtension = @"caf";


### PR DESCRIPTION
This is required when using `pathForResource:ofType` otherwise it looks for
'click.mp3' of type 'mp3', returning a nil path.
